### PR TITLE
Fix & improvements in Linux Build workflow

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -18,8 +18,9 @@ jobs:
           sudo apt-get install clang gcc-multilib
       - run: ./bootstrap
       - run: ./configure --enable-remote-bitbang --enable-jtag_vpi --disable-target64
-      - run: make
+      - run: make -j`nproc`
       - run: file src/openocd | grep 32-bit
+      - run: src/openocd --version
 
 
   # 64-bit, gcc
@@ -37,5 +38,6 @@ jobs:
           sudo apt-get install libusb-1.0-0 libusb-1.0-0-dev
       - run: ./bootstrap
       - run: ./configure --enable-remote-bitbang --enable-jtag_vpi --enable-ftdi-oscan1
-      - run: make
+      - run: make -j`nproc`
       - run: file src/openocd | grep 64-bit
+      - run: src/openocd --version

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -12,7 +12,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      - run: sudo apt-get install clang gcc-multilib
+      - name: Install required packages (apt-get)
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang gcc-multilib
       - run: ./bootstrap
       - run: ./configure --enable-remote-bitbang --enable-jtag_vpi --disable-target64
       - run: make
@@ -28,7 +31,10 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
-      - run: sudo apt-get install libusb-1.0-0 libusb-1.0-0-dev
+      - name: Install required packages (apt-get)
+        run: |
+          sudo apt-get update
+          sudo apt-get install libusb-1.0-0 libusb-1.0-0-dev
       - run: ./bootstrap
       - run: ./configure --enable-remote-bitbang --enable-jtag_vpi --enable-ftdi-oscan1
       - run: make


### PR DESCRIPTION
Fix: added missing apt-get update (otherwise the subsequent apt-get install may end with HTTP 404 errors)

Improvements:
- Use parallel build (use -j for make) .. reduces the CI run time by approx 25%
- Check that the resulting OpenOCD executable can actually be launched (call openocd --version)

Change-Id: I64a85882c7f4d3c897e9f28bedd19c60b2c57191
Signed-off-by: Jan Matyas <matyas@codasip.com>